### PR TITLE
Upgrade chromedriver and headless chromium versions

### DIFF
--- a/actions/common/setup-chrome-driver/action.yml
+++ b/actions/common/setup-chrome-driver/action.yml
@@ -2,15 +2,25 @@ name: Setup Chrome Web-Driver
 description: Installs Serverless Framework to deploy project
 inputs:
 
-  chromedriver-url:
-    description: Dowload URL for chrome driver.
+  headless-chromium-version:
+    description: Headless chromium version to download
     required: false
-    default: https://chromedriver.storage.googleapis.com/86.0.4240.22/chromedriver_linux64.zip
+    default: 1.0.0-41
 
-  headless-chromium-url:
-    description: Download URL for headless chromium. 
+  headless-chromium-filename:
+    description: Headless chromium zip filename to download
     required: false
-    default: https://github.com/adieuadieu/serverless-chrome/releases/download/v1.0.0-57/stable-headless-chromium-amazonlinux-2017-03.zip
+    default: stable-headless-chromium-amazonlinux-2017-03.zip
+
+  chromedriver-version:
+    description: Chrome driver version to download.
+    required: false
+    default: 2.37
+
+  chromedriver-filename:
+    description: Chromedriver zip filename to download
+    required: false
+    default: chromedriver_linux64.zip
 
   default-shell:
     description: Shell used to run steps.
@@ -21,15 +31,15 @@ runs:
   using: composite
   steps:
     - name: Download Chrome Driver
-      run: curl -SL ${{ inputs.chromedriver-url }} > chromedriver.zip
+      run: curl -SL https://chromedriver.storage.googleapis.com/${{ inputs.chromedriver-version }}/${{ inputs.chromedriver-filename }} > chromedriver.zip
       shell: ${{ inputs.default-shell }}
     
     - name: Extract Chrome Driver 
       run: unzip chromedriver.zip -d /opt
       shell: ${{ inputs.default-shell }}
     
-    - name: Download Chromium 
-      run: curl -SL ${{ inputs.headless-chromium-url }} > headless-chromium.zip
+    - name: Download Headless Chromium
+      run: curl -SL https://github.com/adieuadieu/serverless-chrome/releases/download/v${{ inputs.headless-chromium-version }}/${{ inputs.headless-chromium-filename }} > headless-chromium.zip
       shell: ${{ inputs.default-shell }}
 
     - name: Extract Chromium 

--- a/actions/common/setup-chrome-driver/action.yml
+++ b/actions/common/setup-chrome-driver/action.yml
@@ -5,12 +5,12 @@ inputs:
   chromedriver-url:
     description: Dowload URL for chrome driver.
     required: false
-    default: https://chromedriver.storage.googleapis.com/2.37/chromedriver_linux64.zip
+    default: https://chromedriver.storage.googleapis.com/86.0.4240.22/chromedriver_linux64.zip
 
   headless-chromium-url:
     description: Download URL for headless chromium. 
     required: false
-    default: https://github.com/adieuadieu/serverless-chrome/releases/download/v1.0.0-41/stable-headless-chromium-amazonlinux-2017-03.zip
+    default: https://github.com/adieuadieu/serverless-chrome/releases/download/v1.0.0-57/stable-headless-chromium-amazonlinux-2017-03.zip
 
   default-shell:
     description: Shell used to run steps.


### PR DESCRIPTION
This PR upgrades the version of chromedriver and headless chromium needed by envase tracer.

@CurroRodriguez  I am not sure if we need to merge this PR with V1 branch, or create a new branch v2 so that we don't break tt-tracer build.